### PR TITLE
Remove playeranimator from client mods

### DIFF
--- a/Common/src/main/java/de/markusbordihn/modsoptimizer/config/ClientModsDatabase.java
+++ b/Common/src/main/java/de/markusbordihn/modsoptimizer/config/ClientModsDatabase.java
@@ -239,7 +239,6 @@ public class ClientModsDatabase {
           "particlesenhanced",
           "physicsmod",
           "pickupnotifier",
-          "playeranimator",
           "playerhealthindicators",
           "presence-footsteps",
           "puzzle",


### PR DESCRIPTION
This is set to BOTH in the mods.toml, and is indeed required for server because mods that depend on it like combat roll and better combat which are run on the server.